### PR TITLE
setting newTag: sha256 doesn't work

### DIFF
--- a/plain/newtag-digest/kustomization.yaml
+++ b/plain/newtag-digest/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: alpine
+resources:
+- ../base
+images:
+  - name: alpine
+    newTag: sha256:adab3844f497ab9171f070d4cae4114b5aec565ac772e2f2579405b78be67c96


### PR DESCRIPTION
[Actions confirms it](https://github.com/thepwagner/renovate-kustomize-image-digests/runs/3295772090#step:3:43)